### PR TITLE
[CEN-1169] Fix potential null start and end date during cashback phaseout

### DIFF
--- a/core/src/main/java/it/gov/pagopa/rtd/payment_instrument_manager/service/PaymentInstrumentManagerServiceImpl.java
+++ b/core/src/main/java/it/gov/pagopa/rtd/payment_instrument_manager/service/PaymentInstrumentManagerServiceImpl.java
@@ -124,24 +124,29 @@ class PaymentInstrumentManagerServiceImpl implements PaymentInstrumentManagerSer
       }
 
       Map<String, Object> awardPeriodData = paymentInstrumentManagerDao.getAwardPeriods();
+      Map<String, Object> executionDates = paymentInstrumentManagerDao.getRtdExecutionDate();
+
       Object tmpStartDate = awardPeriodData.get("start_date");
       Object tmpEndDate = awardPeriodData.get("end_date");
 
       // During phaseout the award period can be null.
-      // In this case start and end date are null, hence no update is done
+      // In this case start and end date are null, hence no HPANS update is done.
       if (tmpStartDate!=null && tmpEndDate!=null){
         String startDate = String.valueOf(tmpStartDate);
         String endDate = String.valueOf(tmpEndDate);
 
-        Map<String, Object> executionDates = paymentInstrumentManagerDao.getRtdExecutionDate();
+        //Update BPD HPANS
         writeBpdHpansToRtd(String.valueOf(executionDates.get("bpd_exec_date")), startDate,
             endDate);
-        writeFaHpansToRtd(String.valueOf(executionDates.get("fa_exec_date")));
         disableBpdHpans(String.valueOf(executionDates.get("bpd_del_exec_date")), startDate);
-        disableFaHpans(String.valueOf(executionDates.get("fa_del_exec_date")));
-        if (deleteDisabledHpans) {
-            deleteDisabledHpans();
-        }
+      }
+
+      //Update FA HPANS
+      writeFaHpansToRtd(String.valueOf(executionDates.get("fa_exec_date")));
+      disableFaHpans(String.valueOf(executionDates.get("fa_del_exec_date")));
+
+      if (deleteDisabledHpans) {
+        deleteDisabledHpans();
       }
 
       paymentInstrumentManagerDao.updateExecutionDate(saveExecutionDateString);

--- a/core/src/main/java/it/gov/pagopa/rtd/payment_instrument_manager/service/PaymentInstrumentManagerServiceImpl.java
+++ b/core/src/main/java/it/gov/pagopa/rtd/payment_instrument_manager/service/PaymentInstrumentManagerServiceImpl.java
@@ -116,28 +116,35 @@ class PaymentInstrumentManagerServiceImpl implements PaymentInstrumentManagerSer
 
     public void refreshActiveHpans() {
 
-        if (log.isInfoEnabled()) {
-            log.info("PaymentInstrumentManagerServiceImpl.refreshActiveHpans");
-        }
+      OffsetDateTime saveExecutionDate = OffsetDateTime.now();
+      String saveExecutionDateString = saveExecutionDate.toString();
 
-        Map<String,Object> awardPeriodData = paymentInstrumentManagerDao.getAwardPeriods();
-        String startDate = String.valueOf(awardPeriodData.get("start_date"));
-        String endDate = String.valueOf(awardPeriodData.get("end_date"));
+      if (log.isInfoEnabled()) {
+          log.info("PaymentInstrumentManagerServiceImpl.refreshActiveHpans");
+      }
 
-        OffsetDateTime saveExecutionDate = OffsetDateTime.now();
-        String saveExecutionDateString = saveExecutionDate.toString();
+      Map<String, Object> awardPeriodData = paymentInstrumentManagerDao.getAwardPeriods();
+      Object tmpStartDate = awardPeriodData.get("start_date");
+      Object tmpEndDate = awardPeriodData.get("end_date");
 
-        Map<String,Object> executionDates = paymentInstrumentManagerDao.getRtdExecutionDate();
+      // During phaseout the award period can be null.
+      // In this case start and end date are null, hence no update is done
+      if (tmpStartDate!=null && tmpEndDate!=null){
+        String startDate = String.valueOf(tmpStartDate);
+        String endDate = String.valueOf(tmpEndDate);
 
-        writeBpdHpansToRtd(String.valueOf(executionDates.get("bpd_exec_date")), startDate, endDate);
+        Map<String, Object> executionDates = paymentInstrumentManagerDao.getRtdExecutionDate();
+        writeBpdHpansToRtd(String.valueOf(executionDates.get("bpd_exec_date")), startDate,
+            endDate);
         writeFaHpansToRtd(String.valueOf(executionDates.get("fa_exec_date")));
-        disableBpdHpans(String.valueOf(executionDates.get("bpd_del_exec_date")),startDate);
+        disableBpdHpans(String.valueOf(executionDates.get("bpd_del_exec_date")), startDate);
         disableFaHpans(String.valueOf(executionDates.get("fa_del_exec_date")));
         if (deleteDisabledHpans) {
             deleteDisabledHpans();
         }
+      }
 
-        paymentInstrumentManagerDao.updateExecutionDate(saveExecutionDateString);
+      paymentInstrumentManagerDao.updateExecutionDate(saveExecutionDateString);
 
     }
 

--- a/integration/azure-storage/pom.xml
+++ b/integration/azure-storage/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-storage</artifactId>
-            <version>8.6.4</version>
+            <version>8.6.6</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,11 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.22</version>
+        </dependency>
         <!--        TODO: enable only if required-->
         <!--        <dependency>-->
         <!--            <groupId>it.gov.pagopa.bpd</groupId>-->


### PR DESCRIPTION
L’attuale implementazione non contempla la casistica in cui non possa esserci un award period aperto in un dato momento. Questa cosa deve essere gestita.

Il problema di questa logica è che non contempla il fatto che possa non esserci alcun award period attivo in un dato momento (es. l’iniziativa del cashback è finita), e dunque non esegue alcuna validazione riguardo al fatto che la prima query abbia effettivamente restituito dei valori di start_date e end_date. Di conseguenza in mancanza di un award period attivo ai metodi successivi vengono passate delle stringhe contenente null scatenando a runtime una NullPointerException.

Si deve quindi o gestire con un opportuno controllo l’eventuale assenza di un award period attivo, oppure rimuovere del tutto la logica di aggiornamento degli hashpan provenienti dal verticale BPD.

This PR propose a fix, excluding BPD HPAN updates (preserving FA ones).